### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "gatsby-plugin-facebook-sdk",
   "version": "1.0.6",
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ],
   "description": "Gatsby plugin to integrate Facebook Javascript SDK on your project.",
   "author": "Heeryong Kang <drakang4@gamil.com>",
   "repository": {


### PR DESCRIPTION
Update package.json to contain gatsby and gatsby-plugin keywords

Hi there!

I noticed that your package.json was missing the keyword gatsby-plugin. This keyword will enable this plugin to be included in the Gatsby Plugin Library. You can check Gatsby's documentation on how plugins are added.

cc: Gatsby PR for more information about the plugin.